### PR TITLE
Deploy builds in human readable format

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -12,9 +12,6 @@ cp ffmpeg_bin/ffprobe "$FFMPEG_DIR/"
 mkdir -p "$FFMPEG_DIR/man/man1"
 cp ffmpeg_build/share/man/man1/ffmpeg*   "$FFMPEG_DIR/man/man1"
 cp ffmpeg_build/share/man/man1/ffprobe*  "$FFMPEG_DIR/man/man1/"
-mkdir -p "$FFMPEG_DIR/man/man3"
-cp ffmpeg_build/share/man/man3/libav*    "$FFMPEG_DIR/man/man3/"
-cp ffmpeg_build/share/man/man3/libsw*    "$FFMPEG_DIR/man/man3/"
 
 mkdir -p ~/.ssh/
 chmod 700 ~/.ssh/

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,7 +4,9 @@ set -u
 set -e
 
 
-FFMPEG_DIR="ffmpeg_g$(git rev-parse --short HEAD)_d$(date +%s)"
+DATE="$(date +%Y%m%d%H%M%S)"
+COMMIT="$(git rev-parse --short HEAD)"
+FFMPEG_DIR="ffmpeg_d${DATE}_g${COMMIT}"
 mkdir -p "$FFMPEG_DIR"
 
 cp ffmpeg_bin/ffmpeg "$FFMPEG_DIR/"

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,17 +4,17 @@ set -u
 set -e
 
 
-FFMPEG_DIR=ffmpeg_g$(git rev-parse --short HEAD)_d$(date +%s)
-mkdir -p $FFMPEG_DIR
+FFMPEG_DIR="ffmpeg_g$(git rev-parse --short HEAD)_d$(date +%s)"
+mkdir -p "$FFMPEG_DIR"
 
-cp ffmpeg_bin/ffmpeg $FFMPEG_DIR/.
-cp ffmpeg_bin/ffprobe $FFMPEG_DIR/.
-mkdir -p $FFMPEG_DIR/man/man1
-cp ffmpeg_build/share/man/man1/ffmpeg*   $FFMPEG_DIR/man/man1/.
-cp ffmpeg_build/share/man/man1/ffprobe*  $FFMPEG_DIR/man/man1/.
-mkdir -p $FFMPEG_DIR/man/man3
-cp ffmpeg_build/share/man/man3/libav*   $FFMPEG_DIR/man/man3/.
-cp ffmpeg_build/share/man/man3/libsw*  $FFMPEG_DIR/man/man3/.
+cp ffmpeg_bin/ffmpeg "$FFMPEG_DIR/"
+cp ffmpeg_bin/ffprobe "$FFMPEG_DIR/"
+mkdir -p "$FFMPEG_DIR/man/man1"
+cp ffmpeg_build/share/man/man1/ffmpeg*   "$FFMPEG_DIR/man/man1"
+cp ffmpeg_build/share/man/man1/ffprobe*  "$FFMPEG_DIR/man/man1/"
+mkdir -p "$FFMPEG_DIR/man/man3"
+cp ffmpeg_build/share/man/man3/libav*    "$FFMPEG_DIR/man/man3/"
+cp ffmpeg_build/share/man/man3/libsw*    "$FFMPEG_DIR/man/man3/"
 
 mkdir -p ~/.ssh/
 chmod 700 ~/.ssh/
@@ -23,5 +23,4 @@ chmod 400 ~/.ssh/id_rsa
 echo "$DEPLOY_KNOWN_HOSTS" > ~/.ssh/known_hosts
 chmod 400 ~/.ssh/known_hosts
 
-scp -P $DEPLOY_SSH_PORT -r $FFMPEG_DIR $DEPLOY_SSH_USER@$DEPLOY_HOSTNAME:$DEPLOY_PATH | true
-
+scp -P "$DEPLOY_SSH_PORT" -r "$FFMPEG_DIR $DEPLOY_SSH_USER@$DEPLOY_HOSTNAME:$DEPLOY_PATH" | true

--- a/deploy.sh
+++ b/deploy.sh
@@ -22,4 +22,4 @@ chmod 400 ~/.ssh/id_rsa
 echo "$DEPLOY_KNOWN_HOSTS" > ~/.ssh/known_hosts
 chmod 400 ~/.ssh/known_hosts
 
-scp -P "$DEPLOY_SSH_PORT" -r "$FFMPEG_DIR $DEPLOY_SSH_USER@$DEPLOY_HOSTNAME:$DEPLOY_PATH" | true
+scp -P "$DEPLOY_SSH_PORT" -r "$FFMPEG_DIR" "$DEPLOY_SSH_USER@$DEPLOY_HOSTNAME:$DEPLOY_PATH" | true


### PR DESCRIPTION
- Use human readable date format
- Don't deploy library man pages
- Properly quote shell variables