### PR TITLE
Remove `--enable-avresample` from ffmpeg configuration

### DIFF
--- a/build_ffmpeg.sh
+++ b/build_ffmpeg.sh
@@ -448,7 +448,6 @@ compile_with_configure ffmpeg \
                        --enable-frei0r \
                        --enable-librubberband \
                        --enable-avfilter \
-                       --enable-avresample \
                        --enable-bzlib \
                        --enable-zlib \
                        --enable-hardcoded-tables \


### PR DESCRIPTION
FFmpeg removed avresample support in [420cedd49745b284c35d97b936b71ff79b43bdf7](https://git.ffmpeg.org/gitweb/ffmpeg.git/commit/420cedd49745b284c35d97b936b71ff79b43bdf7).